### PR TITLE
Fix 1 basket item sometimes adding 2 items

### DIFF
--- a/src/routes/layout.tsx
+++ b/src/routes/layout.tsx
@@ -12,7 +12,7 @@ export default function Layout() {
       if (prev[sku]) {
         return {
           ...prev,
-          [sku]: { ...prev[sku], quantity: (prev[sku].quantity += quantity) },
+          [sku]: { ...prev[sku], quantity: prev[sku].quantity + quantity },
         };
       } else {
         return { ...prev, [sku]: { ...basketItem, quantity } };


### PR DESCRIPTION
This was caused by incorrect use of `+=` 

fix: do not need to use addition assignment, causing quantity bug